### PR TITLE
fix: make CITATION independent of installing the package

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -2,8 +2,8 @@ bibentry(
   bibtype  = "Manual",
   title    = "{gigs}: Assess Fetal, Newborn, and Child Growth with International Standards",
   author   = c(person(given = c("Simon", "R"), family = "Parker"), person("Linda", "Vesel"), person(given = c("Eric", "O"), family = "Ohuma")),
-  year     = 2024,
-  note     = packageVersion("gigs"),
+  year     = sub("-.*", "", meta$Date),
+  note     = meta$Version,
   url      = "https://github.com/ropensci/gigs/"
 )
 


### PR DESCRIPTION
Fix https://github.com/ropensci/roregistry/issues/48

Sorry we didn't notice this earlier! After this is merged, next time the registry is built your package will be in it. Thank you!